### PR TITLE
Fix audit pickup info, list cell lines details

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -573,7 +573,13 @@ def pickup_selected_vials():
                 )
                 pb['cells'][(vial.row_in_box, vial.col_in_box)] = vial
         db.session.commit()
-        log_audit(current_user.id, 'PICKUP_VIALS', target_type='CryoVial', details=str(used_ids))
+        batch_ids = list({v.batch_id for v in picked_vials})
+        log_audit(
+            current_user.id,
+            'PICKUP_VIALS',
+            target_type='CryoVial',
+            details={'vial_ids': used_ids, 'batch_ids': batch_ids},
+        )
         session.pop('pickup_ids', None)
         flash('Pick up recorded and vials marked as Used.', 'success')
         return render_template(

--- a/app/templates/main/cell_lines.html
+++ b/app/templates/main/cell_lines.html
@@ -5,31 +5,25 @@
     <p><a href="{{ url_for('main.add_cell_line') }}" class="button">Add New Cell Line</a></p>
 
     {% if cell_lines %}
-        <table>
-            <thead>
-                <tr>
-                    <th>Name</th>
-                    <th>Species</th>
-                    <th>Source</th>
-                    <th>Date Established</th>
-                    <th>Actions</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for cl in cell_lines %}
-                    <tr>
-                        <td>{{ cl.name }}</td>
-                        <td>{{ cl.species if cl.species else 'N/A' }}</td>
-                        <td>{{ cl.source if cl.source else 'N/A' }}</td>
-                        <td>{{ cl.date_established.strftime('%Y-%m-%d') if cl.date_established else 'N/A' }}</td>
-                        <td>
-                            <a href="{{ url_for('main.edit_cell_line', cell_line_id=cl.id) }}">Edit</a>
-                            {# Add delete link/button later if needed #}
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+        <ul>
+        {% for cl in cell_lines %}
+            <li>
+                <strong>{{ cl.name }}</strong>
+                <ul>
+                    <li>Species: {{ cl.species if cl.species else 'N/A' }}</li>
+                    <li>Source: {{ cl.source if cl.source else 'N/A' }}</li>
+                    <li>Original Passage: {{ cl.original_passage if cl.original_passage else 'N/A' }}</li>
+                    <li>Culture Medium: {{ cl.culture_medium if cl.culture_medium else 'N/A' }}</li>
+                    <li>Antibiotic Resistance: {{ cl.antibiotic_resistance if cl.antibiotic_resistance else 'N/A' }}</li>
+                    <li>Growth Properties: {{ cl.growth_properties if cl.growth_properties else 'N/A' }}</li>
+                    <li>Mycoplasma Status: {{ cl.mycoplasma_status if cl.mycoplasma_status else 'N/A' }}</li>
+                    <li>Date Established: {{ cl.date_established.strftime('%Y-%m-%d') if cl.date_established else 'N/A' }}</li>
+                    <li>Notes: {{ cl.notes if cl.notes else 'N/A' }}</li>
+                    <li><a href="{{ url_for('main.edit_cell_line', cell_line_id=cl.id) }}">Edit</a></li>
+                </ul>
+            </li>
+        {% endfor %}
+        </ul>
     {% else %}
         <p>No cell lines found. <a href="{{ url_for('main.add_cell_line') }}">Add the first one!</a></p>
     {% endif %}


### PR DESCRIPTION
## Summary
- display detailed cell line info in a nested list
- log vial and batch ids when picking up vials

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68409fa3fda0832cb26d4cb1ac67f9a1