### PR TITLE
Fix backup route for non-sqlite DB

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -11,9 +11,13 @@ from flask import (
     send_file,
 )
 from flask_login import login_required, current_user
-from io import StringIO
+from io import StringIO, BytesIO
 import csv
 import os
+import shutil
+import subprocess
+import tempfile
+from urllib.parse import urlparse
 from sqlalchemy.exc import IntegrityError
 from datetime import datetime
 import json
@@ -1032,9 +1036,46 @@ def clear_all():
 @admin_required
 def backup_database():
     db.session.commit()
-    path = current_app.config['SQLALCHEMY_DATABASE_URI'].replace('sqlite:///', '')
-    log_audit(current_user.id, 'BACKUP_EXPORT', target_type='System')
-    return send_file(path, as_attachment=True, download_name='backup.db')
+    uri = current_app.config['SQLALCHEMY_DATABASE_URI']
+    scheme = urlparse(uri).scheme
+
+    if scheme == 'sqlite':
+        path = uri.replace('sqlite:///', '')
+        log_audit(current_user.id, 'BACKUP_EXPORT', target_type='System')
+        return send_file(path, as_attachment=True, download_name='backup.db')
+
+    if scheme.startswith('postgres'):
+        pg_dump = current_app.config.get('PG_DUMP_PATH')
+        if pg_dump and not os.path.isfile(pg_dump):
+            pg_dump = shutil.which(pg_dump)
+        if not pg_dump:
+            pg_dump = shutil.which('pg_dump') or shutil.which('pg_dump.exe')
+        if not pg_dump:
+            current_app.logger.error('pg_dump command not found')
+            flash('PostgreSQL backup failed.', 'danger')
+            return redirect(url_for('main.index'))
+
+        try:
+            cmd = f'"{pg_dump}" "{uri}"'
+            result = subprocess.run(
+                cmd,
+                shell=True,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            current_app.logger.error('pg_dump failed: %s', exc)
+            flash('PostgreSQL backup failed.', 'danger')
+            return redirect(url_for('main.index'))
+
+        buf = BytesIO(result.stdout)
+        buf.seek(0)
+        log_audit(current_user.id, 'BACKUP_EXPORT', target_type='System')
+        return send_file(buf, as_attachment=True, download_name='backup.sql', mimetype='application/sql')
+
+    flash('Unsupported database type.', 'danger')
+    return redirect(url_for('main.index'))
 
 
 @bp.route('/admin/restore', methods=['GET', 'POST'])
@@ -1045,11 +1086,51 @@ def restore_database():
     if form.validate_on_submit():
         file = form.backup_file.data
         if file:
-            path = current_app.config['SQLALCHEMY_DATABASE_URI'].replace('sqlite:///', '')
-            db.session.remove()
-            file.save(path)
-            log_audit(current_user.id, 'BACKUP_IMPORT', target_type='System')
-            flash('Database restored from backup.', 'success')
+            uri = current_app.config['SQLALCHEMY_DATABASE_URI']
+            scheme = urlparse(uri).scheme
+
+            if scheme == 'sqlite':
+                path = uri.replace('sqlite:///', '')
+                db.session.remove()
+                file.save(path)
+                log_audit(current_user.id, 'BACKUP_IMPORT', target_type='System')
+                flash('Database restored from backup.', 'success')
+
+            elif scheme.startswith('postgres'):
+                psql = current_app.config.get('PSQL_PATH')
+                if psql and not os.path.isfile(psql):
+                    psql = shutil.which(psql)
+                if not psql:
+                    psql = shutil.which('psql') or shutil.which('psql.exe')
+                if not psql:
+                    current_app.logger.error('psql command not found')
+                    flash('PostgreSQL restore failed.', 'danger')
+                    return redirect(url_for('main.index'))
+
+                tmp = tempfile.NamedTemporaryFile(delete=False)
+                try:
+                    file.save(tmp.name)
+                    cmd = f'"{psql}" "{uri}" -f "{tmp.name}"'
+                    subprocess.run(
+                        cmd,
+                        shell=True,
+                        check=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                    )
+                except (OSError, subprocess.CalledProcessError) as exc:
+                    current_app.logger.error('psql restore failed: %s', exc)
+                    flash('PostgreSQL restore failed.', 'danger')
+                    return redirect(url_for('main.index'))
+                finally:
+                    tmp.close()
+                    os.unlink(tmp.name)
+
+                log_audit(current_user.id, 'BACKUP_IMPORT', target_type='System')
+                flash('Database restored from backup.', 'success')
+
+            else:
+                flash('Unsupported database type.', 'danger')
             return redirect(url_for('main.index'))
     return render_template('main/restore_backup.html', form=form, title='Restore Backup')
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -33,9 +33,27 @@ def log_audit(user_id, action, target_type=None, target_id=None, details=None, *
 
 def clear_database_except_admin():
     """Delete all records except users with the admin role."""
-    from app.models import User, CellLine, Tower, Drawer, Box, CryoVial, VialBatch, AuditLog
+    from app.models import (
+        User,
+        CellLine,
+        Tower,
+        Drawer,
+        Box,
+        CryoVial,
+        VialBatch,
+        AuditLog,
+    )
 
-    for model in (CellLine, Tower, Drawer, Box, CryoVial, VialBatch, AuditLog):
+    # Delete dependent tables first to satisfy foreign key constraints
+    for model in (
+        CryoVial,
+        VialBatch,
+        Box,
+        Drawer,
+        Tower,
+        CellLine,
+        AuditLog,
+    ):
         db.session.query(model).delete()
     db.session.query(User).filter(User.role != 'admin').delete()
     db.session.commit()

--- a/config.py
+++ b/config.py
@@ -20,4 +20,7 @@ class Config:
     # SQLAlchemy 配置项，可以关闭一些不必要的通知，提升性能
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
+    PG_DUMP_PATH = os.environ.get('PG_DUMP_PATH')
+    PSQL_PATH = os.environ.get('PSQL_PATH')
+
     # 可以在这里添加其他应用配置...


### PR DESCRIPTION
## Summary
- handle non-sqlite URIs in backup/restore routes
- fix clear_all by deleting in dependency order

## Testing
- `python -m compileall -q app/main/routes.py app/utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6840a40ff604832ca0185f42ff140a30