### PR TITLE
Display available vials in search results

### DIFF
--- a/app/templates/main/cryovial_inventory.html
+++ b/app/templates/main/cryovial_inventory.html
@@ -58,6 +58,7 @@
             <th>Cell Line</th>
             <th>Passage #</th>
             <th>Date Frozen</th>
+            <th>Available</th>
             <th>Volume (uL)</th>
             <th>Concentration</th>
             <th>Fluorescence Tag</th>
@@ -75,6 +76,7 @@
             <td>{{ res.cell_line }}</td>
             <td>{{ res.passage_number }}</td>
             <td>{{ res.date_frozen }}</td>
+            <td>{{ res.available_quantity }}</td>
             <td>{{ res.volume_ml }}</td>
             <td>{{ res.concentration }}</td>
             <td>{{ res.fluorescence_tag }}</td>


### PR DESCRIPTION
## Summary
- update cryovial inventory search table to show available vial counts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841d3ef5e08832c8d2b3e8dd215e9c4